### PR TITLE
JsonRpcMiddleware logging is now separated as a service.

### DIFF
--- a/src/JsonRpc.Host/JsonRpcRequestLogger.cs
+++ b/src/JsonRpc.Host/JsonRpcRequestLogger.cs
@@ -1,0 +1,46 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+
+namespace JsonRpc.Host
+{
+    public interface IJsonRpcRequestLogger
+    {
+        void Log(DateTime requestDate, string requestBody, string responseBody, Diagnostics diagnostics);
+    }
+
+    public class DefaultJsonRpcRequestLogger : IJsonRpcRequestLogger
+    {
+        public DefaultJsonRpcRequestLogger()
+        {
+        }
+        public void Log(DateTime requestDate, string requestBody, string responseBody, Diagnostics diagnostics)
+        {
+        }
+    }
+
+    public class RichInfoJsonRpcRequestLogger : IJsonRpcRequestLogger
+    {
+        public RichInfoJsonRpcRequestLogger(ILoggerFactory loggerFactory)
+        {
+            this.logger = loggerFactory.CreateLogger("JsonRpc.Host.Requests");
+        }
+
+        private readonly ILogger logger;
+
+        public void Log(DateTime requestDate, string requestBody, string responseBody, Diagnostics diagnostics)
+        {
+            this.logger.LogInformation(
+                "startDate: {startDate} request: {request} response: {response} " +
+                "processTime: {processTime} readTime: {readTime} writeTime: {writeTime} totalTime: {totalTime}",
+                requestDate,
+                requestBody,
+                responseBody,
+                diagnostics.ProcessTime,
+                diagnostics.ReadTime,
+                diagnostics.WriteTime,
+                diagnostics.TotalTime
+            );
+        }
+    }
+}

--- a/src/JsonRpc.Host/project.json
+++ b/src/JsonRpc.Host/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.0.0-beta12",
+  "version": "1.0.0-beta13",
   "description": "JsonRpc.Host",
   "authors": [ "Krzysztof Szczuka" ],
   "frameworks": {


### PR DESCRIPTION
Since JsonRpcMiddleware is an internal class I can't really override it outside of the assembly. So the other approach is to have logger as a separate service (i.e. class). These are public and thus visible outside the assembly. Seems to work fine.